### PR TITLE
fix loading commands

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -165,17 +165,17 @@ class SetHotkeyModal extends Modal {
 
 class LeaderPluginSettingsTab extends PluginSettingTab {
   private readonly plugin: LeaderHotkeysPlugin;
-  private readonly commands: Command[];
+  private commands: Command[];
 
   private tempNewHotkey: Hotkey;
 
   constructor(app: App, plugin: LeaderHotkeysPlugin) {
     super(app, plugin);
     this.plugin = plugin;
-    this.commands = this.generateCommandList(app);
   }
 
   public display(): void {
+    this.commands = this.generateCommandList(this.app);
     const { containerEl } = this;
     containerEl.empty();
 


### PR DESCRIPTION
You are generating the commands list in you `onLoad()` function, because the settings pane is added there. Sadly not all commands are loaded at that point. I suggest loading them, when the settings pane is shown, so commands of installed plugins while the plugin is already loaded are supported 

In my case there were around 70 before and 140 commands after the change.

close #7