### PR TITLE
chore: Reduce console spam with console.debug

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -430,7 +430,7 @@ class MatchHandler {
 
   public readonly handleKeyDown = (event: KeyboardEvent): void => {
     const keypress = KeyPress.fromEvent(event);
-    console.log( keypress );
+    console.debug( keypress );
     const machineState = this.machine.advance(keypress);
     writeConsole(
       `An keypress resulted in a ${MatchState[machineState]} state.`,


### PR DESCRIPTION
The plugin spams the console with keypresses. If we really need this, it should be logging to the debug stream otherwise we can get rid of it.