### PR TITLE
fix: Fixed bug with default settings not applying on the first load

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -999,7 +999,7 @@ export default class LeaderHotkeys extends Plugin {
   private readonly loadSavedSettings = async (): Promise<void> => {
     writeConsole('Loading previously saved settings.');
 
-    const savedSettings = (await this.loadData()) || {};
+    const savedSettings = (await this.loadData()) || defaultSettings;
     try {
       savedSettings.hotkeys = (savedSettings.hotkeys || []).map(KeyMap.of);
       this.settings = savedSettings;


### PR DESCRIPTION
Hey! I don't know if this was intentional, but default settings were not loaded on the first launch. I am in the process of making another PR with a feature I need for Vim Mode. And I decided to split PRs.